### PR TITLE
Encode using utf-8 when casting to string

### DIFF
--- a/taurus_pyqtgraph/curvesmodel.py
+++ b/taurus_pyqtgraph/curvesmodel.py
@@ -276,10 +276,12 @@ class TaurusCurveItemTableModel(Qt.QAbstractTableModel):
                 column = parent.columnCount()
         if data.hasFormat(TAURUS_ATTR_MIME_TYPE):
             self.setData(self.index(row, column),
-                         value=str(data.data(TAURUS_ATTR_MIME_TYPE)))
+                         value=str(data.data(TAURUS_ATTR_MIME_TYPE),
+                                   encoding='utf-8'))
             return True
         elif data.hasFormat(TAURUS_MODEL_LIST_MIME_TYPE):
-            models = str(data.data(TAURUS_MODEL_LIST_MIME_TYPE)).split()
+            models = str(data.data(TAURUS_MODEL_LIST_MIME_TYPE),
+                         encoding='utf-8').split()
             if len(models) == 1:
                 self.setData(self.index(row, column),
                              value=models[0])


### PR DESCRIPTION
Fix bug. Encode models using utf-8, instead of a hard cast
to string, in order to allow curves addition to a plot.